### PR TITLE
Enable tailwind css core plugins back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ and this project adheres to [Semantic Versioning][semver].
 
 ---
 
+## [1.15.0] - 06-09-2023
+
+<br>
+
+### Improved
+
+- [pkg-001]\: #81 &nbsp;-&nbsp; fixed tailwindcss core plugins not working (0.6.0)
+  - if we disable vishesh preset core plugins, then enable back corrosponding tailwindcss core plugin
+  - made vishesh preset itself function and accept plugins to be disabled in array
+- [doc-001]\: #81 &nbsp;-&nbsp; updated core plugins document (0.7.0)
+- [doc-001]\: #81 &nbsp;-&nbsp; minor improvement in overall docs (0.7.0)
+- [play-001]\: #81 &nbsp;-&nbsp; improved tailwindcss config file (0.3.0)
+- [play-002]\: #81 &nbsp;-&nbsp; improved tailwindcss config file (0.3.0)
+
+<br />
+
+### Removed
+
+- [pkg-001]\: #81 &nbsp;-&nbsp; removed `vishehsCorePlugins` option from config (0.6.0)
+
+<br /><br />
+
+---
+
 ## [1.11.3] - 29-08-2023
 
 <br>
@@ -389,6 +413,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 शुभारम्भः
 
+[1.15.0]: https://github.com/mrjadeja/vishesh/commit/6867d3df...f709c3c1
 [1.11.3]: https://github.com/mrjadeja/vishesh/commit/f4521692...6867d3df
 [1.11.2]: https://github.com/mrjadeja/vishesh/commit/3bded435...f4521692
 [1.11.1]: https://github.com/mrjadeja/vishesh/commit/6e5ad8f8...3bded435

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vishesh",
   "description": "The ui design system build on top of the tailwindcss ✌",
-  "version": "1.11.3",
+  "version": "1.15.0",
   "type": "module",
   "scripts": {
     "clear": "pnpx rimraf --glob **/node_modules **/dist **/types **/.turbo **/.next **/tsconfig.tsbuildinfo",

--- a/src/docs/CHANGELOG.md
+++ b/src/docs/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning][semver].
 
 ---
 
+## [0.7.0] - 06-09-2023
+
+<br>
+
+### Improved
+
+- #81 &nbsp;-&nbsp; updated core plugins document
+- #81 &nbsp;-&nbsp; minor improvement in overall docs
+
+<br /><br />
+
+---
+
 ## [0.6.3] - 29-08-2023
 
 <br>
@@ -177,6 +190,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 शुभारम्भः
 
+[0.7.0]: https://github.com/mrjadeja/vishesh/commit/6867d3df...f709c3c1
 [0.6.3]: https://github.com/mrjadeja/vishesh/commit/f4521692...6867d3df
 [0.6.2]: https://github.com/mrjadeja/vishesh/commit/3bded435...f4521692
 [0.6.1]: https://github.com/mrjadeja/vishesh/commit/6e5ad8f8...3bded435

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -1,6 +1,6 @@
 # Vishesh docs
 
-_The official documentation of vishesh_
+_The official documentation of vishesh project_
 
 <br />
 

--- a/src/docs/package.json
+++ b/src/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs",
-  "description": "The official documentation of vishesh",
-  "version": "0.6.3",
+  "description": "The official documentation of vishesh project",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/src/docs/pages/preset/configurations/core-plugins.mdx
+++ b/src/docs/pages/preset/configurations/core-plugins.mdx
@@ -2,27 +2,36 @@ import { Callout } from "nextra-theme-docs";
 
 # Core Plugins
 
-The Vishesh Preset is a collection of plugins similar to Tailwind CSS. It generates classes only for the enabled plugins, ensuring that you have precisely what you need—no more and no less.
+The Vishesh Preset is a collection of plugins similar to Tailwind CSS. It generates classes only for the enabled plugins, ensuring that you have precisely what you need — no more and no less.
 
-By default, all the core plugins are enabled. To disable any of them, you can use `visheshCorePlugins`.
+By default, all the core plugins are enabled. To disable any of them, add theme to disable array as shown below
 
 ```js filename="tailwind.config.js"
 export default {
   // ...
-  visheshCorePlugins: {
-    breakpoints: true,
-    container: true,
-    // ...
-  },
+  presets: [
+    vishesh({
+      disable: ["container"],
+    }),
+  ],
   // ...
 };
 ```
+
+<Callout type="warning">
+  <em>If you disable any of **Depends on**</em>
+  <em> core plugin as shown in the below list,</em>
+  <em> The dependent core plugin also got disabled.</em>
+</Callout>
+<Callout type="info">
+  <em>If you disable `breakpoints`, then `container` also disabled.</em>
+</Callout>
 
 <br />
 
 ## List of plugins
 
-| Core Plugins | Documentation                 |
-| :----------- | :---------------------------- |
-| breakpoints  | [Read](../layout/breakpoints) |
-| container    | [Read](../layout/container)   |
+| Core Plugins | Documentation                 | Depends on                           |
+| :----------- | :---------------------------- | :----------------------------------- |
+| breakpoints  | [Read](../layout/breakpoints) |                                      |
+| container    | [Read](../layout/container)   | [breakpoints](../layout/breakpoints) |

--- a/src/docs/pages/preset/installation.mdx
+++ b/src/docs/pages/preset/installation.mdx
@@ -69,7 +69,7 @@ v3 or higher
 > <em>you can extend or override [config][tailwind-config]</em>
 
 ```diff filename="tailwind.config.js"
-# /* your imports */
+# /* your other imports */
 + import vishesh from "vishesh-preset";
 
 # /* remove tailwindcss auto suggestion */
@@ -77,7 +77,7 @@ v3 or higher
 # /* add tailwindcss + vishesh-preset auto suggestion */
 + /** @type {import('vishesh-preset/types').VisheshPreset} */
   export default {
-+   presets: [vishesh],
++   presets: [vishesh()],
     content: [____],
     theme: {
 #     // ...
@@ -96,14 +96,15 @@ v3 or higher
 > <em>you can extend or override [config][tailwind-config]</em>
 
 ```diff filename="tailwind.config.cjs"
-# /* your imports */
+# /* your other imports */
++ const vishesh = require("vishesh-preset");
 
 # /* remove tailwindcss auto suggestion */
 - /** @type {import('tailwindcss').Config} */
 # /* add tailwindcss + vishesh-preset auto suggestion */
 + /** @type {import('vishesh-preset/types').VisheshPreset} */
   module.exports = {
-+   presets: [require("vishesh-preset")],
++   presets: [vishesh()],
     content: [____],
     theme: {
 #     // ...

--- a/src/docs/pages/preset/layout/breakpoints.mdx
+++ b/src/docs/pages/preset/layout/breakpoints.mdx
@@ -9,13 +9,13 @@ When a screen hits a breakpoint, the design switches to a version that fits that
 <br />
 
 <Callout type="warning">
-  <em>We disabled `screens` and added `breakpoints`.</em>
+  <em>You have to remove `screens` config from your config file.</em>
 </Callout>
 
 ```diff filename="tailwind.config.js"
 # Default breakpoints are in pixels
 {
-  content: [____],
+#  // ...
   theme: {
 -    screens: {
 -      zero: 0,
@@ -43,7 +43,7 @@ When a screen hits a breakpoint, the design switches to a version that fits that
 +     },
     }
   },
-  plugins: [____]
+# // ...
 }
 ```
 
@@ -63,7 +63,8 @@ These breakpoints are not just regular breakpoints. Vishesh generates a bunch of
 It has `minimum` + `maximum` + `range` + `only` variants included 🤘.
 
 <Callout type="info">
-  <em>This docs website itself using the vishesh preset breakpoint.</em>
+  <em>Tailwindcss has the solution, but it's little verbose.</em> <br />
+  <em>See [basic usage](#basic-usage) for comparision.</em>
 </Callout>
 
 <br />
@@ -73,7 +74,11 @@ It has `minimum` + `maximum` + `range` + `only` variants included 🤘.
 <details>
   <summary>Toggle content</summary>
 
-> <em>usually we use this breakpoint variants</em>
+> <em>usually we use this breakpoint variants</em> <br />
+> <em>
+>   <abbr title="Also known as">a.k.a</abbr>
+> </em>
+> <em>forward breakpoint variants</em>
 
 | Variant | Media Query                |
 | :------ | :------------------------- |
@@ -93,7 +98,7 @@ It has `minimum` + `maximum` + `range` + `only` variants included 🤘.
   <summary>Toggle content</summary>
 
 > <em>Just prepend `r` to breakpoint variants</em> <br />
-> <em>where `r` stands for `reverse` breakpoint</em>
+> <em>where `r` stands for `reverse` breakpoint variant</em>
 
 | Variant | Media Query                                     |
 | :------ | :---------------------------------------------- |
@@ -138,7 +143,7 @@ It has `minimum` + `maximum` + `range` + `only` variants included 🤘.
   <summary>Toggle content</summary>
 
 > <em>Just prepend `o` to breakpoint variants</em> <br />
-> <em>where `o` stands for `only` breakpoint</em>
+> <em>where `o` stands for `only` breakpoint variant</em>
 
 | Variant | Media Query                                        |
 | :------ | :------------------------------------------------- |

--- a/src/docs/pages/preset/layout/container/fixed.mdx
+++ b/src/docs/pages/preset/layout/container/fixed.mdx
@@ -3,7 +3,7 @@ import { Callout } from "nextra-theme-docs";
 # Fixed container
 
 <Callout type="info">
-  <em>max-width = breakpoint - ( 2 * spacing )</em> <br />
+  <em>`max-width = breakpoint - ( 2 * spacing )`</em> <br />
   <em>_please refer_ [breakpoints][breakpoints]</em>
 </Callout>
 

--- a/src/docs/pages/preset/layout/container/fluid.mdx
+++ b/src/docs/pages/preset/layout/container/fluid.mdx
@@ -3,7 +3,7 @@ import { Callout } from "nextra-theme-docs";
 # Fluid container
 
 <Callout type="info">
-  <em>width = 100% - ( 2 * spacing )</em> <br />
+  <em>`width = 100% - ( 2 * spacing )`</em> <br />
   <em>_please refer_ [breakpoints][breakpoints]</em>
 </Callout>
 

--- a/src/docs/pages/preset/layout/container/index.mdx
+++ b/src/docs/pages/preset/layout/container/index.mdx
@@ -4,14 +4,11 @@ import { Callout, Tabs, Tab } from "nextra-theme-docs";
 
 A container in responsive web design is a wrapper element that provides a structured and adaptable layout for content.
 
-<Callout type="info">
-  <em>Tailwind has a container. but, it is very limited.</em>
-</Callout>
-
 <Callout type="warning">
   <em>Vishesh preset container is _**`tightly bounded with breakpoints`**_.</em>
   <em> so, it only generates container classes for</em>
   <em> breakpoints that's defined in the configurations.</em>
+  <em> [Know more](/preset/configurations/core-plugins#list-of-plugins)</em>
 </Callout>
 
 <br />

--- a/src/docs/pages/preset/layout/container/twin.mdx
+++ b/src/docs/pages/preset/layout/container/twin.mdx
@@ -4,7 +4,7 @@ import { Callout } from "nextra-theme-docs";
 
 If you choose _Fixed_ or _Fluid_ container then, you can use only one of them in your project. But, what if you want to use both of them together?
 
-Introducing the _Twin container_. though there are a little change in class names and few rules.
+Introducing the _Twin container_ with a little change in class names and few rules.
 
 <Callout type="info">
   <em>You can use fixed and fluid container</em>

--- a/src/docs/tailwind.config.js
+++ b/src/docs/tailwind.config.js
@@ -2,7 +2,7 @@ import vishesh from "vishesh-preset";
 
 /** @type {import('vishesh-preset/types').VisheshPreset} */
 export default {
-  presets: [vishesh],
+  presets: [vishesh()],
   darkMode: "class",
   content: [
     "./pages/**/*.{jsx,mdx}",

--- a/src/packages/preset/CHANGELOG.md
+++ b/src/packages/preset/CHANGELOG.md
@@ -13,13 +13,33 @@ and this project adheres to [Semantic Versioning][semver].
 
 ---
 
+## [0.6.0] - 06-09-2023
+
+<br>
+
+### Improved
+
+- #81 &nbsp;-&nbsp; fixed tailwindcss core plugins not working
+  - if we disable vishesh preset core plugins, then enable back corrosponding tailwindcss core plugin
+  - made vishesh preset itself function and accept plugins to be disabled in array
+
+<br />
+
+### Removed
+
+- #81 &nbsp;-&nbsp; removed `vishehsCorePlugins` option from config
+
+<br /><br />
+
+---
+
 ## [0.5.0] - 29-08-2023
 
 <br>
 
 ### Added
 
-- Added `visheshCorePlugins` to provide option for enabling / disabling core plugins
+- added `visheshCorePlugins` to provide option for enabling / disabling core plugins
 
 <br /><br />
 
@@ -170,6 +190,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 शुभारम्भः
 
+[0.6.0]: https://github.com/mrjadeja/vishesh/commit/6e5ad8f8...f709c3c1
 [0.5.0]: https://github.com/mrjadeja/vishesh/commit/af778dea...6e5ad8f8
 [0.4.0]: https://github.com/mrjadeja/vishesh/commit/51b34689...af778dea
 [0.1.8]: https://github.com/mrjadeja/vishesh/commit/780a6ee8...51b34689

--- a/src/packages/preset/lib/components/container/index.ts
+++ b/src/packages/preset/lib/components/container/index.ts
@@ -12,16 +12,7 @@
 
 import { isObject } from "../../utils";
 
-import type {
-  BaseProperties,
-  MediaQueryProperties,
-  TwinSpacing,
-  ContainerMode,
-  InnerPadding,
-  Spacing,
-} from "./types";
 import type { PluginProps } from "../..";
-import type { Breakpoints } from "../../variants/breakpoints/types";
 
 // container
 // center: boolean

--- a/src/packages/preset/lib/components/container/types.d.ts
+++ b/src/packages/preset/lib/components/container/types.d.ts
@@ -1,4 +1,4 @@
-export interface BaseProperties {
+interface BaseProperties {
   width: "100%";
   display: "block";
   marginLeft?: "auto";
@@ -7,20 +7,20 @@ export interface BaseProperties {
   paddingRight: string | number;
 }
 
-export type ContainerMode = "fixed" | "fluid" | "twin";
+type ContainerMode = "fixed" | "fluid" | "twin";
 
-export type InnerPadding =
+type InnerPadding =
   | number
   | string
   | Record<keyof Breakpoints, number | string>;
 
-export interface MediaQueryProperties {
+interface MediaQueryProperties {
   maxWidth?: number;
   paddingLeft: number | string;
   paddingRight: number | string;
 }
 
-export type Spacing = Record<keyof Breakpoints, number>;
+type Spacing = Record<keyof Breakpoints, number>;
 
 interface FixedContainer extends BaseContainer {
   mode: "fixed";
@@ -41,7 +41,7 @@ interface TwinContainer extends BaseContainer {
   innerPadding: InnerPadding;
 }
 
-export interface TwinSpacing extends Spacing {
+interface TwinSpacing extends Spacing {
   fixed?: Spacing;
   fluid?: Spacing;
 }
@@ -50,13 +50,11 @@ interface BaseContainer {
   mode: ContainerMode;
   spacing: Spacing;
   /**
-   * @deprecated
-   * > 🚨 Do not use
+   * > 🚨 Do not use if using vishesh breakpoints
    */
   screens?: never;
   /**
-   * @deprecated
-   * > 🚨 Do not use
+   * > 🚨 Do not use if using vishesh container
    */
   padding?: never;
 }

--- a/src/packages/preset/lib/components/index.ts
+++ b/src/packages/preset/lib/components/index.ts
@@ -1,9 +1,10 @@
 import container from "./container";
 
-import type { PluginProps } from "..";
+import type { PluginProps, VisheshCorePluginsList } from "..";
 
-export default function (props: PluginProps): void {
-  !!props.visheshCorePlugins.breakpoints &&
-    !!props.visheshCorePlugins.container &&
-    container(props);
+export default function (
+  props: PluginProps,
+  disabledPluginList: VisheshCorePluginsList[]
+): void {
+  !disabledPluginList.includes("container") && container(props);
 }

--- a/src/packages/preset/lib/index.d.ts
+++ b/src/packages/preset/lib/index.d.ts
@@ -12,17 +12,11 @@ type Merge<A, B> = {
     : never;
 };
 
-interface VisheshCorePlugins {
-  breakpoints: boolean;
-  container: boolean;
-}
-
-export interface PluginProps {
+interface PluginProps {
   theme: Function;
   addComponents: Function;
   addVariant: Function;
   config: Function;
-  visheshCorePlugins: VisheshCorePlugins;
 }
 
 interface ThemeDefaults {
@@ -32,7 +26,15 @@ interface ThemeDefaults {
 
 type Theme = ThemeConfig & ThemeDefaults;
 
-interface VisheshPreset extends Config {
-  theme: Partial<Theme & { extend: Partial<Theme> }>;
-  visheshCore: VisheshCore;
+interface VisheshConfig {
+  disable: VisheshCorePluginsList[];
 }
+
+// To disable vishesh core plugins and enable back tailwindcss core plugins
+type VisheshCorePluginsList = "breakpoints" | "container";
+
+export interface VisheshPreset extends Config {
+  theme: VisheshThemeConfig;
+}
+
+type VisheshThemeConfig = Partial<Theme & { extend: Partial<Theme> }>;

--- a/src/packages/preset/lib/themeDefaults.ts
+++ b/src/packages/preset/lib/themeDefaults.ts
@@ -37,8 +37,4 @@ export default {
       },
     },
   },
-  visheshCorePlugins: {
-    breakpoints: true,
-    container: true,
-  },
 } satisfies Partial<VisheshPreset>;

--- a/src/packages/preset/lib/utils.ts
+++ b/src/packages/preset/lib/utils.ts
@@ -1,3 +1,62 @@
+import type { Merge, VisheshCorePluginsList, VisheshThemeConfig } from ".";
+import type { CorePluginList } from "tailwindcss/types/generated/corePluginList";
+
+export const getDisabledPluginsList = (
+  disabledVisheshCorePlugins: VisheshCorePluginsList[]
+) => {
+  return Object.entries(dependencyList)
+    .map(([key, value]) => {
+      if (
+        value.some((plugin: any) => disabledVisheshCorePlugins.includes(plugin))
+      ) {
+        return key;
+      }
+      return;
+    })
+    .filter(Boolean) as VisheshCorePluginsList[];
+};
+
+const dependencyList: Record<VisheshCorePluginsList, VisheshCorePluginsList[]> =
+  {
+    breakpoints: ["breakpoints"],
+    container: ["container", "breakpoints"],
+  };
+
 export const isObject = (obj: any): boolean => {
   return obj && typeof obj === "object" && !Array.isArray(obj);
+};
+
+export const transformTailwindConfig = (
+  disabledVisheshCorePlugins: VisheshCorePluginsList[]
+) => {
+  const theme: Partial<VisheshThemeConfig> = {
+    // disabled with override as corePlugins not working
+    screens: {},
+  };
+  const corePlugins: Partial<Record<CorePluginList, boolean>> = {
+    container: false,
+  };
+
+  // vishesh core plugins and tailwindcss core plugins mapping
+  const corePluginsMapping: Record<
+    VisheshCorePluginsList,
+    Merge<CorePluginList, "screens">
+  > = {
+    breakpoints: "screens",
+    container: "container",
+  };
+  // disabled tailwindcss core plugin with override
+  // there is an issue or plugin doesn't exist in tailwindcss
+  const caveatPlugins: Merge<CorePluginList, "screens">[] = ["screens"];
+  // if dev disables the vishesh core plugins then,
+  // enable back the tailwindcss core plugins
+  disabledVisheshCorePlugins.forEach((corePlugin) => {
+    if (caveatPlugins.includes(corePluginsMapping[corePlugin])) {
+      delete theme[corePluginsMapping[corePlugin] as CorePluginList];
+    } else {
+      delete corePlugins[corePluginsMapping[corePlugin] as CorePluginList];
+    }
+  });
+
+  return { theme, corePlugins };
 };

--- a/src/packages/preset/lib/variants/breakpoints/index.ts
+++ b/src/packages/preset/lib/variants/breakpoints/index.ts
@@ -12,7 +12,6 @@
 
 import { isObject } from "../../utils";
 
-import type { Breakpoints } from "./types";
 import type { PluginProps } from "../..";
 
 /**

--- a/src/packages/preset/lib/variants/breakpoints/types.d.ts
+++ b/src/packages/preset/lib/variants/breakpoints/types.d.ts
@@ -1,1 +1,1 @@
-export type Breakpoints = Record<string, number>;
+type Breakpoints = Record<string, number>;

--- a/src/packages/preset/lib/variants/index.ts
+++ b/src/packages/preset/lib/variants/index.ts
@@ -1,7 +1,10 @@
 import breakpoints from "./breakpoints";
 
-import type { PluginProps } from "..";
+import type { PluginProps, VisheshCorePluginsList } from "..";
 
-export default function (props: PluginProps): void {
-  !!props.visheshCorePlugins.breakpoints && breakpoints(props);
+export default function (
+  props: PluginProps,
+  disabledPluginList: VisheshCorePluginsList[]
+): void {
+  !disabledPluginList.includes("breakpoints") && breakpoints(props);
 }

--- a/src/packages/preset/package.json
+++ b/src/packages/preset/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vishesh-preset",
   "description": "The tailwind css preset to rapidly build any UI",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "check:typescript": "tsc --noEmit true --emitDeclarationOnly false",

--- a/src/playground/preset/cjs/CHANGELOG.md
+++ b/src/playground/preset/cjs/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning][semver].
 
 ---
 
+## [0.3.0] - 06-09-2023
+
+<br>
+
+### Improved
+
+- #81 &nbsp;-&nbsp; improved tailwindcss config file
+
+<br /><br />
+
+---
+
 ## [0.2.0] - 26-08-2023
 
 <br>
@@ -47,6 +59,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 शुभारम्भः
 
+[0.3.0]: https://github.com/mrjadeja/vishesh/commit/af778dea...f709c3c1
 [0.2.0]: https://github.com/mrjadeja/vishesh/compare/b7f440a2...af778dea
 [0.1.0]: https://github.com/mrjadeja/vishesh/compare/60e5816f...b7f440a2
 [0.0.1]: https://github.com/mrjadeja/vishesh/compare/0be58e6a...60e5816f "Initial Setup"

--- a/src/playground/preset/cjs/package.json
+++ b/src/playground/preset/cjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "play-preset-cjs",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "commonjs",
   "scripts": {
     "dev": "vite"

--- a/src/playground/preset/cjs/tailwind.config.js
+++ b/src/playground/preset/cjs/tailwind.config.js
@@ -1,9 +1,10 @@
 // your other imports
+const vishesh = require("vishesh-preset");
 
 /** @type {import('vishesh-preset/types').VisheshPreset} */
-module.exports = {
+const theme = {
   content: ["./index.html", "./style.css"],
-  presets: [require("vishesh-preset")],
+  presets: [vishesh()],
   theme: {
     extend: {
       breakpoints: {
@@ -34,3 +35,7 @@ module.exports = {
   },
   plugins: [],
 };
+
+console.log("theme", theme.presets);
+
+module.exports = theme;

--- a/src/playground/preset/esm/CHANGELOG.md
+++ b/src/playground/preset/esm/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning][semver].
 
 ---
 
+## [0.3.0] - 06-09-2023
+
+<br>
+
+### Improved
+
+- #81 &nbsp;-&nbsp; improved tailwindcss config file
+
+<br /><br />
+
+---
+
 ## [0.2.0] - 26-08-2023
 
 <br>
@@ -47,6 +59,7 @@ and this project adheres to [Semantic Versioning][semver].
 
 शुभारम्भः
 
+[0.3.0]: https://github.com/mrjadeja/vishesh/commit/af778dea...f709c3c1
 [0.2.0]: https://github.com/mrjadeja/vishesh/compare/b7f440a2...af778dea
 [0.1.0]: https://github.com/mrjadeja/vishesh/compare/60e5816f...b7f440a2
 [0.0.1]: https://github.com/mrjadeja/vishesh/compare/0be58e6a...60e5816f "Initial Setup"

--- a/src/playground/preset/esm/package.json
+++ b/src/playground/preset/esm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "play-preset",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite"

--- a/src/playground/preset/esm/tailwind.config.js
+++ b/src/playground/preset/esm/tailwind.config.js
@@ -2,9 +2,9 @@
 import vishesh from "vishesh-preset";
 
 /** @type {import('vishesh-preset/types').VisheshPreset} */
-export default {
+const theme = {
   content: ["./index.html", "./style.css"],
-  presets: [vishesh],
+  presets: [vishesh()],
   theme: {
     extend: {
       breakpoints: {
@@ -35,3 +35,7 @@ export default {
   },
   plugins: [],
 };
+
+console.log("theme", theme.presets);
+
+export default theme;


### PR DESCRIPTION
* Resolved #81 

* Enable back tailwindcss core plugins If dev want to disable some vishesh preset core plugins, enable back corresponding tailwindcss core plugins

* Update docs #81

* Update changelogs #81 